### PR TITLE
Adding search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Commands:
   list        List properties for a repository
   set         Set a property for a repository
   schema      Get the schema for an organization
+  search      Search for a matching property value in a repository
 
 Options:
   -r <owner/repo>   Specify the owner and repository name
@@ -39,4 +40,7 @@ Examples:
   gh prop set -r octocat/hello-world -p Team -v "Team A"
   gh prop schema
   gh prop schema octocat
+  gh prop search -v "Any value"
+  gh prop search -p "Team" -v "Team A"
+  gh prop search -r octocat/hello-world -p "Team" -v "Team A"
 ````

--- a/gh-prop
+++ b/gh-prop
@@ -2,6 +2,8 @@
 set -e
 
 usage() {
+  exit_code="${1:-0}" # Use the passed in param as exit code or default to '0'
+
   cat <<EOF
 Usage: gh prop <command> [options]
 
@@ -29,6 +31,7 @@ Examples:
   gh prop search -r octocat/hello-world -p "Team" -v "Team A"
 }
 EOF
+exit "$exit_code"
 }
 
 set_property() {
@@ -36,23 +39,21 @@ set_property() {
   local prop
   local value
   if [ $# -eq 0 ]; then
-    usage
-    return 1
+    usage 1
   fi
 
   while getopts "r:p:v:" opt; do
     case $opt in
-      r) repo="$OPTARG" ;;
-      p) prop="$OPTARG" ;;
-      v) value="$OPTARG" ;;
-      *) usage ;;
+      r) repo="$OPTARG";;
+      p) prop="$OPTARG";;
+      v) value="$OPTARG";;
+      *) usage 1;;
     esac
   done
 
   if [ -z "$prop" ] || [ -z "$value" ]; then
     echo "error: missing required option" >&2
-    usage
-    return 1
+    usage 1
   fi
 
   gh api \
@@ -68,14 +69,13 @@ list() {
 
   while getopts "r:" opt; do
     case $opt in
-      r) repo="$OPTARG" ;;
-      *) usage ;;
+      r) repo="$OPTARG";;
+      *) usage 1;;
     esac
   done
 
   if [ -z "$repo" ]; then
-    usage
-    return 1
+    usage 1
   fi
 
   gh api \
@@ -99,7 +99,7 @@ search() {
   local prop
   local value
   if [ $# -eq 0 ]; then
-    usage && exit 1
+    usage 1
   fi
 
   while getopts "r:p:v:" opt; do
@@ -107,13 +107,13 @@ search() {
       r) repo="$OPTARG";;
       p) prop="$OPTARG";;
       v) value="$OPTARG";;
-      *) usage && exit 1;;
+      *) usage 1;;
     esac
   done
 
   if [ -z "$value" ]; then
     echo "error: missing required option" >&2
-    usage && exit 1
+    usage 1
   fi
 
   repo_props="$(gh prop list -r "${repo}")"
@@ -148,8 +148,10 @@ list)
 schema)
   schema "$@"
   ;;
+search)
+  search "$@"
+  ;;
 *)
-  usage >&2
-  exit 1
+  usage 1 >&2
   ;;
 esac

--- a/gh-prop
+++ b/gh-prop
@@ -11,6 +11,7 @@ Commands:
   list        List properties for a repository
   set         Set a property for a repository
   schema      Get the schema for an organization
+  search      Search for a matching property value in a repository
 
 Options:
   -r <owner/repo>   Specify the owner and repository name
@@ -23,6 +24,9 @@ Examples:
   gh prop set -r octocat/hello-world -p Team -v "Team A"
   gh prop schema
   gh prop schema octocat
+  gh prop search -v "Any value"
+  gh prop search -p "Team" -v "Team A"
+  gh prop search -r octocat/hello-world -p "Team" -v "Team A"
 }
 EOF
 }
@@ -88,6 +92,44 @@ schema() {
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   /orgs/"$owner"/properties/schema
+}
+
+search() {
+  local repo='{owner}/{repo}'
+  local prop
+  local value
+  if [ $# -eq 0 ]; then
+    usage && exit 1
+  fi
+
+  while getopts "r:p:v:" opt; do
+    case $opt in
+      r) repo="$OPTARG";;
+      p) prop="$OPTARG";;
+      v) value="$OPTARG";;
+      *) usage && exit 1;;
+    esac
+  done
+
+  if [ -z "$value" ]; then
+    echo "error: missing required option" >&2
+    usage && exit 1
+  fi
+
+  repo_props="$(gh prop list -r "${repo}")"
+
+  if [ -z "$prop" ]; then
+    result="$(echo "$repo_props" | jq ".[] | .value == \"${value}\"")"
+  else
+    result="$(echo "$repo_props" | jq ".[] | select(.property_name == \"${prop}\") | .value == \"${value}\"")"
+  fi
+
+  if [[ "$result" =~ "true" ]]; then
+    echo "✅ Found a match: '${repo}'"
+  else
+    echo "❌ No match: '${repo}'"
+    exit 1
+  fi
 }
 
 cmd="$1"


### PR DESCRIPTION
# What
Adds:
``` shell
# Search for any value in the current repo's custom properties
gh prop search -v "Any value"

# Search for a specific custom property's value in the current repo
gh prop search -p "Team" -v "Team A"

# Search for a specific custom property's value in a given repo
gh prop search -r octocat/hello-world -p "Team" -v "Team A"
```

I've avoided using the [list endpoint](https://docs.github.com/en/rest/orgs/custom-properties?apiVersion=2022-11-28#list-custom-property-values-for-organization-repositories) since:
- it requires pagination
- it doesn't allow for filtering archived repos

## How I've used this
``` shell
# Generate a list of the current active repos with "full name" (e.g. 'org/repo')
gh repo list fac --no-archived --json 'nameWithOwner' --jq '.[].nameWithOwner' --limit 500 | sort > list_of_repos

# Iterate through the list of active repos looking for a given property:
while IFS= read -r full_repo_name; do
        gh prop search -r "$full_repo_name" -p "Team" -v "Dev Platform"
done < list_of_repos

# Output
❌ No match: 'fac/<repo1>'
✅ Found a match: 'fac/<repo2>'
❌ No match: 'fac/<repo3>'
```